### PR TITLE
Add contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,26 @@
+# How to Contribute
+
+I'm so delighted that you want to contribute to ExomodPackager!
+Please take a moment to familiarize yourself with the expectations.
+
+## Reporting Issues
+
+Before reporting a new issue, please ensure that the issue was not already reported or fixed by searching through the [issues list](https://github.com/suzicurran/ExomodPackager/issues).
+
+When creating a new issue, be sure to select the appropriate template ("feature" or "bug") based on what you want to discuss and include a title, clear description, and (for bugs) a reproducible test case.
+
+## Sending Pull Requests
+
+Before sending a new pull request, take a look at existing [pull requests](https://github.com/suzicurran/ExomodPackager/pulls) and issues to see if the proposed change or fix has been discussed in the past, or if the change was already implemented but not yet released.
+
+We expect new pull requests to include complete descriptions, including testing details, screenshots, and other details to enable a quick and complete assessment of the change.
+
+## Community Behavior
+
+We expect contributors to uphold a welcoming and harassment-free environment for all. Examples of behavior that contributes to creating a positive environment include being respectful of differing viewpoints and experiences, and gracefully accepting constructive criticism. Project maintainers can and will take corrective action in response to any instances of unacceptable behavior.
+
+
+
+Thanks again for your interest in contributing to ExomodPackager!
+
+:sparkles: :rocket: :sparkles:


### PR DESCRIPTION
# Description

This adds a relatively brief CONTRIBUTING file to describe expectations for contributing to ExomodPackager. It does not establish any new ways of working (example: a feature or development branch) and does not require changes to any other docs.

Fixes #2 

## Type of Change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change has a corresponding PR in another repository (https://github.com/suzicurran/ExomodLoader/pull/9)
- [x] This change requires a documentation update

# How Has This Been Tested?

Markdown has been "tested" by viewing the rich diff [here](https://github.com/suzicurran/ExomodPackager/pull/4/files?short_path=eca12c0#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055) to confirm formatting of headers and emoji works as expected. Links have been click-tested and open appropriate pages.

# Checklist:

- [x] I have performed a self-review of my own diff
- [x] I have included corresponding changes to the documentation

# Screenshots

![image](https://user-images.githubusercontent.com/8042502/195940707-dcb02fbf-91e5-42bd-a449-b37c5f7f05be.png)